### PR TITLE
Allow support of arrays and properties within keys

### DIFF
--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -43,7 +43,7 @@
         'name': 'keyword.other.definition.ini'
       '2':
         'name': 'punctuation.separator.key-value.ini'
-    'match': '^([a-zA-Z0-9_.-\\[\\]]+)\\s*(=)'
+    'match': '^([\\[\\]a-zA-Z0-9_.-]+)\\s*(=)'
   }
   {
     'captures':


### PR DESCRIPTION
Adds support for arrays in the following formats within ini configuration files.

``` ini
files = "example1"
files.array[] = "more example"
files[] = "another_example"
files[example_files] = "test"
```
