### PR TITLE
Ensure comments are at start of line. Fixes #5

### DIFF
--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -4,7 +4,7 @@
 'name': 'Ini'
 'patterns': [
   {
-    'begin': '(^[ \\t]+)?(?=#)'
+    'begin': '^([\\s]+)?(?=#)'
     'beginCaptures':
       '1':
         'name': 'punctuation.whitespace.comment.leading.ini'
@@ -21,7 +21,7 @@
     ]
   }
   {
-    'begin': '(^[ \\t]+)?(?=;)'
+    'begin': '^([\\s]+)?(?=;)'
     'beginCaptures':
       '1':
         'name': 'punctuation.whitespace.comment.leading.ini'
@@ -43,7 +43,7 @@
         'name': 'keyword.other.definition.ini'
       '2':
         'name': 'punctuation.separator.key-value.ini'
-    'match': '^([\\[\\]a-zA-Z0-9_.-]+)\\s*(=)'
+    'match': '^([\\[\\][\\s*]a-zA-Z0-9_.-]+)\\s*(=)'
   }
   {
     'captures':


### PR DESCRIPTION
Couple of ini spec violations here which were fixed:

- Comments are only at the beginning of lines.
- Enables multiple words to be used as the value.