### PR TITLE
Add `inf` to allowed filetypes

### DIFF
--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -1,4 +1,5 @@
 'fileTypes': [
+  'inf',
   'ini'
 ]
 'name': 'Ini'


### PR DESCRIPTION
`inf` is a plain text format used by Microsoft operating systems which bares very similar resemblance to `ini` standards.