### PR TITLE
Allow comments anywhere in the document

### DIFF
--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -7,7 +7,7 @@
 'name': 'INI'
 'patterns': [
   {
-    'begin': '^([\\s]+)?(?=#)'
+    'begin': '(^[\\s]+)?(?=#)'
     'beginCaptures':
       '1':
         'name': 'punctuation.whitespace.comment.leading.ini'
@@ -24,7 +24,7 @@
     ]
   }
   {
-    'begin': '^([\\s]+)?(?=;)'
+    'begin': '(^[\\s]+)?(?=;)'
     'beginCaptures':
       '1':
         'name': 'punctuation.whitespace.comment.leading.ini'


### PR DESCRIPTION
Despite how loose the INI spec is, some languages allow comments at the end of
the line and not having the ability to highlight those may cause confusion to
the people who are using parsers that allow that.

This piggy backs of the work by @j2ghz in #11 with an additional line for the
comments starting with '#'.

Fixes #26, #10 and #11.