### PR TITLE
Added .cfg and .conf file formats

### DIFF
--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -2,7 +2,9 @@
   'inf',
   'desktop',
   'directory',
-  'ini'
+  'ini',
+  'cfg',
+  'conf'
 ]
 'name': 'INI'
 'patterns': [


### PR DESCRIPTION
As [wiki](https://www.wikiwand.com/en/INI_file) says, INI files have wider use than just `.ini` files. So it would be more more convenient, if the editor self chooses syntax.
