### PR TITLE
Add .cfg to supported file types

### DIFF
--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -2,7 +2,8 @@
   'inf',
   'desktop',
   'directory',
-  'ini'
+  'ini',
+  'cfg'
 ]
 'name': 'INI'
 'patterns': [


### PR DESCRIPTION
Add support for '.cfg' file. This file type is used in python the same way as '.ini' file.