### PR TITLE
Add .ica file extension

### DIFF
--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -1,9 +1,10 @@
 'fileTypes': [
-  'inf',
+  'cfg',
   'desktop',
   'directory',
-  'ini',
-  'cfg'
+  'ica',
+  'inf',
+  'ini'
 ]
 'name': 'INI'
 'patterns': [


### PR DESCRIPTION
Citrix’ connection files are just INI files, so treat them that way.

This also reorders the file extensions alphabetically.