### PR TITLE
Create a separate grammar for `.desktop` files

### DIFF
--- a/grammars/desktop.cson
+++ b/grammars/desktop.cson
@@ -1,14 +1,10 @@
 'fileTypes': [
-  'cfg',
-  'directory',
-  'ica',
-  'inf',
-  'ini'
+  'desktop',
 ]
 'name': 'INI'
 'patterns': [
   {
-    'begin': '(^[\\s]+)?(?=#)'
+    'begin': '^([\\s]+)?(?=#)'
     'beginCaptures':
       '1':
         'name': 'punctuation.whitespace.comment.leading.ini'
@@ -25,7 +21,7 @@
     ]
   }
   {
-    'begin': '(^[\\s]+)?(?=;)'
+    'begin': '^([\\s]+)?(?=;)'
     'beginCaptures':
       '1':
         'name': 'punctuation.whitespace.comment.leading.ini'


### PR DESCRIPTION
As we are well aware, every tool has their own intereptation of the ini
syntax and up until now, I've dumped them all into a single grammar. I
learnt the other day you can split these out and restrict it to certain
file types so it makes sense to so that we can treat `.desktop` comments
differently to others.

Fixes #33