### PR TITLE
Feat: integer and boolean support added to grammar

### DIFF
--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -9,6 +9,10 @@
 'name': 'INI'
 'patterns': [
   {
+    'match': '\\s(\\d+)\\s'
+    'name': 'constant.integer.ini'
+  }
+  {
     'begin': '(^[\\s]+)?(?=#)'
     'beginCaptures':
       '1':

--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -13,6 +13,10 @@
     'name': 'constant.integer.ini'
   }
   {
+    'match': '\\s(true|false)\\s'
+    'name': 'constant.boolean.ini'
+  }
+  {
     'begin': '(^[\\s]+)?(?=#)'
     'beginCaptures':
       '1':

--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -1,5 +1,6 @@
 'fileTypes': [
   'cfg',
+  'conf',
   'directory',
   'ica',
   'inf',

--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -1,6 +1,5 @@
 'fileTypes': [
   'cfg',
-  'conf',
   'directory',
   'ica',
   'inf',

--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -8,11 +8,11 @@
 'name': 'INI'
 'patterns': [
   {
-    'match': '\\s(\\d+)\\s'
+    'match': '\\s?(\\d+)\\s?'
     'name': 'constant.integer.ini'
   }
   {
-    'match': '\\s(true|false)\\s'
+    'match': '\\s?(true|false)\\s?'
     'name': 'constant.boolean.ini'
   }
   {


### PR DESCRIPTION
#### Changes Made for PR:

* `.conf` file extension support
* integer (number) grammar highlighting
* boolean (true/fase) grammar highlighting

_PS. Not sure if I am the only one with the need for the `.conf` extension I added, but I figure the more the merrier!_