### PR TITLE
Use ".desktop" for desktop grammar name

### DIFF
--- a/grammars/desktop.cson
+++ b/grammars/desktop.cson
@@ -1,7 +1,7 @@
 'fileTypes': [
   'desktop',
 ]
-'name': 'INI'
+'name': '.desktop'
 'patterns': [
   {
     'begin': '^([\\s]+)?(?=#)'


### PR DESCRIPTION
Fixes #40 
https://github.com/jacobbednarz/atom-language-ini/issues/33#issuecomment-314324354
