### PR TITLE
Catch floats.

### DIFF
--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -9,12 +9,16 @@
 'name': 'INI'
 'patterns': [
   {
-    'match': '\\s?(\\d+)\\s?'
-    'name': 'constant.integer.ini'
-  }
-  {
     'match': '\\s?(true|false)\\s?'
     'name': 'constant.boolean.ini'
+  }
+  {
+    'match': '\\s?([-+]?[0-9]*\.?[0-9]+)\\s?'
+    'name': 'constant.float.ini'
+  }
+  {
+    'match': '\\s?(\\d+)\\s?'
+    'name': 'constant.integer.ini'
   }
   {
     'begin': '(^[\\s]+)?(?=#)'
@@ -94,6 +98,10 @@
       '0':
         'name': 'punctuation.definition.string.end.ini'
     'name': 'string.quoted.double.ini'
+  }
+  {
+    'match': '\\s?(.*|\n)\\s'
+    'name': 'constant.string.ini'
   }
 ]
 'scopeName': 'source.ini'

--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -13,7 +13,7 @@
     'name': 'constant.boolean.ini'
   }
   {
-    'match': '\\s?([-+]?[0-9]*\.?[0-9]+)\\s?'
+    'match': '\\s?([-+]?[\\d]*\.?[\\d]+)\\s?'
     'name': 'constant.float.ini'
   }
   {

--- a/grammars/ini.cson
+++ b/grammars/ini.cson
@@ -99,9 +99,5 @@
         'name': 'punctuation.definition.string.end.ini'
     'name': 'string.quoted.double.ini'
   }
-  {
-    'match': '\\s?(.*|\n)\\s'
-    'name': 'constant.string.ini'
-  }
 ]
 'scopeName': 'source.ini'


### PR DESCRIPTION
I added support for floats and strings that don't have quotes around them. So, now floats will be marked with "orange". Before, only integers were marked - dots in floats appeared with white colour. Also, strings that are not quoted will also be caught by the expression in the end of the "ini.cson" file. They will have green colour as quoted strings.
Please, check this before merging. I have tested it with every combination I could think of, but I could be wrong.
Great work on the plugin by the way! Thanks!
Let me know of any questions.