### PR TITLE
Scopename conflict patch

### DIFF
--- a/grammars/desktop.cson
+++ b/grammars/desktop.cson
@@ -83,4 +83,4 @@
     'name': 'string.quoted.double.ini'
   }
 ]
-'scopeName': 'source.ini'
+'scopeName': 'source.desktop'

--- a/settings/language-ini.cson
+++ b/settings/language-ini.cson
@@ -1,3 +1,6 @@
 '.source.ini':
   'editor':
     'commentStart': '; '
+'.source.desktop':
+  'editor':
+    'commentStart': '; '


### PR DESCRIPTION
Patch for https://github.com/jacobbednarz/atom-language-ini/issues/42, separating into `source.desktop` and `source.ini`